### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-{  
+{
   "proxy": "http://localhost:8181",
   "name": "never-note",
   "version": "0.1.0",


### PR DESCRIPTION

Hello ephong!

It seems like you have npm as one of your (dev-) dependency in never-note-front.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
